### PR TITLE
Add retro style and public catalog access

### DIFF
--- a/catalog/views.py
+++ b/catalog/views.py
@@ -8,18 +8,18 @@ from .forms import ConsoleForm, ComputerForm, VideoGameForm, BoardGameForm
 from .filters import ConsoleFilter, ComputerFilter, VideoGameFilter, BoardGameFilter
 
 
-class IndexView(LoginRequiredMixin, generic.TemplateView):
+class IndexView(generic.TemplateView):
     template_name = "catalog/index.html"
 
 
-class ConsoleListView(LoginRequiredMixin, FilterView):
+class ConsoleListView(FilterView):
     model = Console
     paginate_by = 10
     filterset_class = ConsoleFilter
     template_name = "catalog/console_list.html"
 
 
-class ConsoleDetailView(LoginRequiredMixin, generic.DetailView):
+class ConsoleDetailView(generic.DetailView):
     model = Console
     template_name = "catalog/console_detail.html"
 
@@ -44,14 +44,14 @@ class ConsoleDeleteView(LoginRequiredMixin, generic.DeleteView):
     success_url = reverse_lazy("catalog:console_list")
 
 
-class ComputerListView(LoginRequiredMixin, FilterView):
+class ComputerListView(FilterView):
     model = Computer
     paginate_by = 10
     filterset_class = ComputerFilter
     template_name = "catalog/computer_list.html"
 
 
-class ComputerDetailView(LoginRequiredMixin, generic.DetailView):
+class ComputerDetailView(generic.DetailView):
     model = Computer
     template_name = "catalog/computer_detail.html"
 
@@ -76,14 +76,14 @@ class ComputerDeleteView(LoginRequiredMixin, generic.DeleteView):
     success_url = reverse_lazy("catalog:computer_list")
 
 
-class VideoGameListView(LoginRequiredMixin, FilterView):
+class VideoGameListView(FilterView):
     model = VideoGame
     paginate_by = 10
     filterset_class = VideoGameFilter
     template_name = "catalog/videogame_list.html"
 
 
-class VideoGameDetailView(LoginRequiredMixin, generic.DetailView):
+class VideoGameDetailView(generic.DetailView):
     model = VideoGame
     template_name = "catalog/videogame_detail.html"
 
@@ -108,14 +108,14 @@ class VideoGameDeleteView(LoginRequiredMixin, generic.DeleteView):
     success_url = reverse_lazy("catalog:videogame_list")
 
 
-class BoardGameListView(LoginRequiredMixin, FilterView):
+class BoardGameListView(FilterView):
     model = BoardGame
     paginate_by = 10
     filterset_class = BoardGameFilter
     template_name = "catalog/boardgame_list.html"
 
 
-class BoardGameDetailView(LoginRequiredMixin, generic.DetailView):
+class BoardGameDetailView(generic.DetailView):
     model = BoardGame
     template_name = "catalog/boardgame_detail.html"
 
@@ -140,28 +140,28 @@ class BoardGameDeleteView(LoginRequiredMixin, generic.DeleteView):
     success_url = reverse_lazy("catalog:boardgame_list")
 
 
-class ConsoleTimelineView(LoginRequiredMixin, generic.ListView):
+class ConsoleTimelineView(generic.ListView):
     model = Console
     template_name = "catalog/timeline.html"
     paginate_by = 20
     ordering = ["release_year"]
 
 
-class ComputerTimelineView(LoginRequiredMixin, generic.ListView):
+class ComputerTimelineView(generic.ListView):
     model = Computer
     template_name = "catalog/timeline.html"
     paginate_by = 20
     ordering = ["release_year"]
 
 
-class VideoGameTimelineView(LoginRequiredMixin, generic.ListView):
+class VideoGameTimelineView(generic.ListView):
     model = VideoGame
     template_name = "catalog/timeline.html"
     paginate_by = 20
     ordering = ["release_year"]
 
 
-class BoardGameTimelineView(LoginRequiredMixin, generic.ListView):
+class BoardGameTimelineView(generic.ListView):
     model = BoardGame
     template_name = "catalog/timeline.html"
     paginate_by = 20

--- a/static/css/retro.css
+++ b/static/css/retro.css
@@ -1,0 +1,49 @@
+body {
+    font-family: 'Press Start 2P', monospace;
+    background-color: #1a1a1a;
+    color: #eaeaea;
+}
+
+.navbar-brand,
+.nav-link,
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Press Start 2P', monospace;
+}
+
+a {
+    color: #ffd700;
+}
+
+a:hover, a:focus {
+    color: #ffea70;
+}
+
+.btn-primary,
+.btn-outline-primary {
+    background-color: #008080;
+    border-color: #008080;
+}
+
+.btn-primary:hover,
+.btn-outline-primary:hover {
+    background-color: #00a0a0;
+    border-color: #00a0a0;
+}
+
+.btn-outline-secondary {
+    border-color: #ffd700;
+    color: #ffd700;
+}
+
+.btn-outline-secondary:hover {
+    background-color: #ffd700;
+    color: #1a1a1a;
+}
+
+.table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: #2a2a2a;
+}
+
+.table-striped > tbody > tr:nth-of-type(even) {
+    background-color: #1f1f1f;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,10 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Century Video Games{% endblock %}</title>
+    {% load static %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'css/retro.css' %}">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4" role="navigation">
     <div class="container-fluid">
         <a class="navbar-brand" href="{% url 'catalog:index' %}">Museum</a>
         <div class="collapse navbar-collapse">
@@ -18,9 +23,9 @@
                 <li class="nav-item"><a class="nav-link" href="{% url 'catalog:boardgame_list' %}">Board Games</a></li>
             </ul>
             {% if user.is_authenticated %}
-            <a class="btn btn-outline-secondary" href="{% url 'logout' %}">Logout</a>
+            <a class="btn btn-outline-secondary" href="{% url 'logout' %}" aria-label="Logout">Logout</a>
             {% else %}
-            <a class="btn btn-outline-primary" href="{% url 'login' %}">Login</a>
+            <a class="btn btn-outline-primary" href="{% url 'login' %}" aria-label="Login">Login</a>
             {% endif %}
         </div>
     </div>

--- a/templates/catalog/timeline.html
+++ b/templates/catalog/timeline.html
@@ -6,7 +6,7 @@
   {% for obj in object_list %}
   <li class="list-group-item">
     {% with photo=obj.photos.first %}
-        {% if photo %}{% thumbnail photo.image "150x100" crop="center" as im %}<img src="{{ im.url }}" class="me-2" />{% endthumbnail %}{% endif %}
+        {% if photo %}{% thumbnail photo.image "150x100" crop="center" as im %}<img src="{{ im.url }}" class="me-2" alt="{{ photo.caption }}" />{% endthumbnail %}{% endif %}
     {% endwith %}
     <a href="{{ obj.get_absolute_url }}">{{ obj.name }} ({{ obj.release_year }})</a>
   </li>


### PR DESCRIPTION
## Summary
- update base template with retro font and CSS
- add retro color scheme and high-contrast styles
- open catalog list/detail/timeline pages to public visitors
- add alt text in timeline images for WCAG compliance

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68407d3543208326943d886cfc0b4364