### PR TITLE
Add troubleshooting for translation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.sqlite3
 db.sqlite3
 media/
+
+# Ignore compiled translation files
+*.mo

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Accede a [http://127.0.0.1:8000](http://127.0.0.1:8000) y explora la colección.
 
 Consulta el tablero de [GitHub Projects](https://github.com/users/danimap27/projects/5) para ver el progreso y las *issues* activas.
 
+## ❓ Solución de problemas
+
+Si al ejecutar `python manage.py runserver` aparece el error:
+
+```
+struct.error: unpack requires a buffer of 4 bytes
+```
+
+es probable que exista un archivo de traducciones compilado (`.mo`) dañado.
+Elimina los ficheros `*.mo` dentro de `locale/*/LC_MESSAGES/` y vuelve a
+compilarlos con:
+
+```bash
+django-admin compilemessages
+```
+
 ## 🤝 Contribuir
 
 1. Abre una *issue* para proponer cambio o reportar bug.


### PR DESCRIPTION
## Summary
- ignore compiled translation files
- document how to fix a `struct.error` when an invalid `.mo` exists

## Testing
- `python manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a881952c8326859d2d74bd802175