### PR TITLE
Improve responsive design and header color

### DIFF
--- a/catalog/management/commands/scrape_20thcv.py
+++ b/catalog/management/commands/scrape_20thcv.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+import requests
+from bs4 import BeautifulSoup
+
+class Command(BaseCommand):
+    help = "Scrape a subset of 20thCenturyVideoGames.com"
+
+    def add_arguments(self, parser):
+        parser.add_argument('--limit', type=int, default=10, help='Number of items to fetch')
+
+    def handle(self, *args, **options):
+        limit = options['limit']
+        url = "https://20thcenturyvideogames.com/index.php?action=listas&tipo=4"
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        entries = []
+        for link in soup.select('.footer_list a')[:limit]:
+            entries.append(link.text.strip())
+        for e in entries:
+            self.stdout.write(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ django-filter==25.1
 openai==1.84.0
 pillow==11.2.1
 sorl-thumbnail==12.11.0
+requests==2.32.2
+beautifulsoup4==4.12.3

--- a/static/css/retro.css
+++ b/static/css/retro.css
@@ -9,6 +9,8 @@
   --crt-panel:   #233026; /* navbar, tarjetas */
   --card-bg:     #273627; /* card +1 tono    */
 
+  --header-bg:  #2c3e50; /* nuevo color cabecera */
+
   --crt-text:    #c6f9b9; /* texto base      */
   --crt-muted:   #9bd89e; /* subtítulos      */
   --crt-accent:  #ffb84d; /* naranja Atari   */
@@ -55,7 +57,7 @@ a:hover { opacity: .85; text-decoration: underline; }
 .navbar {
   display: flex;
   flex-wrap: wrap;            /* permite que se parta en 2 líneas */
-  background: var(--crt-panel);
+  background: var(--header-bg);
   padding: .5rem 1rem;
   border-bottom: 1px solid rgba(255,255,255,.1);
 }
@@ -75,6 +77,11 @@ a:hover { opacity: .85; text-decoration: underline; }
   .navbar-brand   { font-size: 1rem; }
   .nav-link       { font-size: .75rem; }
   body            { font-size: 14px; }
+  .navbar-nav     { flex-direction: column; width: 100%; }
+}
+
+@media (max-width: 768px){
+  .navbar-nav { flex-direction: column; width: 100%; }
 }
 
 /* ==========  CONTENEDOR  ========== */
@@ -167,3 +174,7 @@ table, .form-control, .form-select {
 /* ==========  UTILIDADES  ========== */
 .text-accent { color: var(--crt-accent) !important; }
 .bg-panel   { background: var(--crt-panel) !important; }
+
+@media (max-width: 575px){
+  .card { margin-bottom: 1rem; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="{% static 'css/retro.css' %}">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4" role="navigation">
+<nav class="navbar navbar-expand-lg navbar-dark mb-4" role="navigation">
     <div class="container-fluid">
         <a class="navbar-brand" href="{% url 'catalog:index' %}">{% trans "Museum" %}</a>
         <div class="collapse navbar-collapse">


### PR DESCRIPTION
## Summary
- tweak header to use darker style
- add new header color variable in CSS
- update responsive behaviors for navbar and cards
- include example scraper to read data from 20thCenturyVideoGames
- update dependencies for requests and BeautifulSoup

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6840aeb1ed4c83268d9e07d8fbf63899