### PR TITLE
Add navigation for timeline views

### DIFF
--- a/catalog/views.py
+++ b/catalog/views.py
@@ -146,6 +146,11 @@ class ConsoleTimelineView(generic.ListView):
     paginate_by = 20
     ordering = ["release_year"]
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["timeline_type"] = "consoles"
+        return context
+
 
 class ComputerTimelineView(generic.ListView):
     model = Computer
@@ -153,12 +158,22 @@ class ComputerTimelineView(generic.ListView):
     paginate_by = 20
     ordering = ["release_year"]
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["timeline_type"] = "computers"
+        return context
+
 
 class VideoGameTimelineView(generic.ListView):
     model = VideoGame
     template_name = "catalog/timeline.html"
     paginate_by = 20
     ordering = ["release_year"]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["timeline_type"] = "videogames"
+        return context
 
 
 class BoardGameTimelineView(generic.ListView):

--- a/templates/catalog/timeline.html
+++ b/templates/catalog/timeline.html
@@ -3,6 +3,11 @@
 {% load i18n %}
 {% block content %}
 <h1>{% trans "Timeline" %}</h1>
+<nav class="nav nav-pills mb-3">
+  <a class="nav-link {% if timeline_type == 'consoles' %}active{% endif %}" href="{% url 'catalog:console_timeline' %}">{% trans "Consoles" %}</a>
+  <a class="nav-link {% if timeline_type == 'computers' %}active{% endif %}" href="{% url 'catalog:computer_timeline' %}">{% trans "Computers" %}</a>
+  <a class="nav-link {% if timeline_type == 'videogames' %}active{% endif %}" href="{% url 'catalog:videogame_timeline' %}">{% trans "Video Games" %}</a>
+</nav>
 <ul class="list-group">
   {% for obj in object_list %}
   <li class="list-group-item">


### PR DESCRIPTION
## Summary
- allow switching between console, computer, and videogame timelines

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6840b09b7c0c8326970d16398a9fa0ed